### PR TITLE
Changing http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Key features;
 Add the following lines to your build.sbt
 
 ```
-resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
 libraryDependencies += "io.github.martintrojer" % "frins_2.10" % "0.1-SNAPSHOT"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.10.2"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
 
-resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
 libraryDependencies += "io.github.martintrojer" % "atom-scala_2.10" % "0.1-SNAPSHOT"
 


### PR DESCRIPTION
Hi! Thanks for great package. I was trying to use it, and encountered a problem while compiling with sbt. I realized resolver with http was not working, it was giving an error as below. Changing http to https in build.sbt fixed the issue.

```
[warn] ==== Sonatype snapshots: tried
[warn]   http://oss.sonatype.org/content/repositories/snapshots/io/github/martintrojer/atom-scala_2.10/0.1-SNAPSHOT/atom-scala_2.10-0.1-SNAPSHOT.pom
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: io.github.martintrojer#atom-scala_2.10;0.1-SNAPSHOT: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
```

I hope you find this helpful.
